### PR TITLE
Fix codebook loading error when .npz path is passed to extractor

### DIFF
--- a/src/extraction/robust_extractor.py
+++ b/src/extraction/robust_extractor.py
@@ -92,7 +92,24 @@ class RobustSynthIDExtractor:
             self.load_codebook(codebook_path)
     
     def load_codebook(self, path: str) -> None:
-        """Load pre-extracted codebook."""
+        """Load pre-extracted codebook. Supports .pkl files and auto-discovers
+        .pkl when given a .npz path (common user mistake)."""
+        if path.endswith('.npz'):
+            pkl_candidates = [
+                os.path.join(os.path.dirname(path), 'codebook', 'robust_codebook.pkl'),
+                os.path.join(os.path.dirname(path), 'robust_codebook.pkl'),
+                path.replace('.npz', '.pkl'),
+            ]
+            for pkl_path in pkl_candidates:
+                if os.path.exists(pkl_path):
+                    with open(pkl_path, 'rb') as f:
+                        self.codebook = pickle.load(f)
+                    return
+            raise FileNotFoundError(
+                f"Cannot load .npz as pickle codebook. "
+                f"Provide a .pkl file instead, e.g.: "
+                f"--detector artifacts/codebook/robust_codebook.pkl"
+            )
         with open(path, 'rb') as f:
             self.codebook = pickle.load(f)
     
@@ -100,7 +117,7 @@ class RobustSynthIDExtractor:
         """Save extracted codebook."""
         os.makedirs(os.path.dirname(path) if os.path.dirname(path) else '.', exist_ok=True)
         with open(path, 'wb') as f:
-            pickle.dump(self.codebook, f)
+            pickle.dump(self.codebook, f, protocol=4)
     
     # ================================================================
     # DENOISING METHODS

--- a/src/extraction/synthid_codebook_extractor.py
+++ b/src/extraction/synthid_codebook_extractor.py
@@ -201,9 +201,9 @@ def extract_codebook(image_dir, output_path, max_images=250, size=512):
     # Save codebook
     os.makedirs(os.path.dirname(output_path) if os.path.dirname(output_path) else '.', exist_ok=True)
     
-    # Save as pickle (includes numpy arrays)
+    # Save as pickle (includes numpy arrays, protocol=4 for compatibility)
     with open(output_path, 'wb') as f:
-        pickle.dump(codebook, f)
+        pickle.dump(codebook, f, protocol=4)
     
     # Save metadata as JSON
     json_path = output_path.replace('.pkl', '_meta.json')


### PR DESCRIPTION
## Problem

When running the bypass, users pass `--codebook artifacts/spectral_codebook_v3.npz` (as shown in the README). The bypass script then passes this same `.npz` path to `robust_extractor.load_codebook()`, which calls `pickle.load()` on it. Since `.npz` is a numpy format (not pickle), this throws:

```
Warning: Could not load extractor: A load persistent id instruction was encountered,
but no persistent_load function was specified.
```

This causes the extractor to silently fail, so users get **no before/after watermark verification** during bypass. The bypass reports "Success: True" but users have no way to confirm it actually worked — leading to confusion in #9, #10, and #11.

## Root Cause

`robust_extractor.py`'s `load_codebook()` blindly calls `pickle.load()` on whatever file path it receives. When the bypass script falls back to the `--codebook` arg (an `.npz` file), pickle tries to parse numpy binary data and fails with a misleading error.

## Fix

- **`load_codebook()`** now detects `.npz` paths and auto-discovers the matching `.pkl` codebook in `artifacts/codebook/`
- **`pickle.dump()`** calls now use `protocol=4` explicitly for wider Python version compatibility

## Before/After

**Before** (no verification, warning printed):
```
Warning: Could not load extractor: A load persistent id instruction...
SYNTHID BYPASS RESULTS
  Success: True
  (no before/after watermark comparison)
```

**After** (verification works):
```
SYNTHID BYPASS RESULTS
  Success: True
  Before Bypass:
    is_watermarked: True
    confidence: 0.674
  After Bypass:
    is_watermarked: False
    confidence: 0.674
```

## Test plan

- [x] Reproduced the original error with `--codebook artifacts/spectral_codebook_v3.npz`
- [x] Verified fix resolves the warning and enables before/after verification
- [x] Confirmed bypass still works correctly (watermark detected before, removed after)
- [x] Tested `.pkl` codebook loading still works directly

Fixes #10, #9, #11